### PR TITLE
Feature/add abilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@testing-library/user-event": "^7.1.2",
     "axios": "^0.19.2",
     "connected-react-router": "^6.7.0",
-    "gm-common": "0.1.0",
+    "gm-common": "0.1.1",
     "history": "^4.10.1",
     "node-sass": "^4.13.1",
     "pusher-js": "^5.1.1",

--- a/src/components/NewCharacter/NewCharacter.js
+++ b/src/components/NewCharacter/NewCharacter.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { string, func } from 'prop-types';
-import { characters } from 'gm-common';
+import { characters, characterProperties } from 'gm-common';
 import TextInput from '../common/TextInput/TextInput';
 import Button from '../common/Button/Button';
 import Dropdown from '../common/Dropdown/Dropdown';
+import PlusMinuser from '../common/PlusMinuser/PlusMinuser';
 import styles from './NewCharacter.module.scss';
 
 const characterClassOptions = [
@@ -44,10 +45,21 @@ const NewCharacter = ({ gameId, createCharacter }) => {
   const [characterRace, setCharacterRace] = useState(characterRaceOptions[0].value);
   const [characterOrder, setCharacterOrder] = useState(characterOrderOptions[0].value);
   const [characterMorality, setCharacterMorality] = useState(characterMoralityOptions[0].value);
+  const [characterRoll] = useState(characterProperties.rollCharacter());
+  const [strength, setStrength] = useState(characterRoll.scores[0]);
+  const [dexterity, setDexterity] = useState(characterRoll.scores[1]);
+  const [constitution, setConstitution] = useState(characterRoll.scores[2]);
+  const [intelligence, setIntelligence] = useState(characterRoll.scores[3]);
+  const [wisdom, setWisdom] = useState(characterRoll.scores[4]);
+  const [charisma, setCharisma] = useState(characterRoll.scores[5]);
+
+  const remainingAbilityPoints =
+    characterRoll.total - (strength + dexterity + constitution + intelligence + wisdom + charisma);
+  const canIncrementAbilities = remainingAbilityPoints > 0;
 
   return (
     <div className={styles.newCharacter}>
-      <div className={styles.characterInput}>
+      <div className={[styles.characterInput, styles.column1].join(' ')}>
         <div className={styles.label}>Character Name</div>
         <TextInput
           autofocus
@@ -57,7 +69,7 @@ const NewCharacter = ({ gameId, createCharacter }) => {
           onChange={setCharacterName}
         />
       </div>
-      <div className={styles.characterInput}>
+      <div className={[styles.characterInput, styles.column1].join(' ')}>
         <div className={styles.label}>Character Class</div>
         <Dropdown
           className={styles.classDropdown}
@@ -68,7 +80,7 @@ const NewCharacter = ({ gameId, createCharacter }) => {
           onOptionSelected={option => setCharacterClass(option)}
         />
       </div>
-      <div className={styles.characterInput}>
+      <div className={[styles.characterInput, styles.column1].join(' ')}>
         <div className={styles.label}>Character Race</div>
         <Dropdown
           className={styles.raceDropdown}
@@ -79,7 +91,7 @@ const NewCharacter = ({ gameId, createCharacter }) => {
           onOptionSelected={option => setCharacterRace(option)}
         />
       </div>
-      <div className={styles.characterInput}>
+      <div className={[styles.characterInput, styles.column1].join(' ')}>
         <div className={styles.label}>Order</div>
         <Dropdown
           className={styles.orderDropdown}
@@ -89,6 +101,8 @@ const NewCharacter = ({ gameId, createCharacter }) => {
           selectedOption={characterOrder}
           onOptionSelected={option => setCharacterOrder(option)}
         />
+      </div>
+      <div className={[styles.characterInput, styles.column1].join(' ')}>
         <div className={styles.label}>Morality</div>
         <Dropdown
           className={styles.moralityDropdown}
@@ -99,8 +113,64 @@ const NewCharacter = ({ gameId, createCharacter }) => {
           onOptionSelected={option => setCharacterMorality(option)}
         />
       </div>
+      <div className={styles.abilitiesContainer}>
+        <PlusMinuser
+          label='Strength'
+          initialValue={strength}
+          min={characterRoll.min}
+          max={characterRoll.max}
+          canIncrement={canIncrementAbilities}
+          onChange={setStrength}
+        />
+        <PlusMinuser
+          label='Dexterity'
+          initialValue={dexterity}
+          min={characterRoll.min}
+          max={characterRoll.max}
+          canIncrement={canIncrementAbilities}
+          onChange={setDexterity}
+        />
+        <PlusMinuser
+          label='Constitution'
+          initialValue={constitution}
+          min={characterRoll.min}
+          max={characterRoll.max}
+          canIncrement={canIncrementAbilities}
+          onChange={setConstitution}
+        />
+        <PlusMinuser
+          label='Intelligence'
+          initialValue={intelligence}
+          min={characterRoll.min}
+          max={characterRoll.max}
+          canIncrement={canIncrementAbilities}
+          onChange={setIntelligence}
+        />
+        <PlusMinuser
+          label='Wisdom'
+          initialValue={wisdom}
+          min={characterRoll.min}
+          max={characterRoll.max}
+          canIncrement={canIncrementAbilities}
+          onChange={setWisdom}
+        />
+        <PlusMinuser
+          label='Charisma'
+          initialValue={charisma}
+          min={characterRoll.min}
+          max={characterRoll.max}
+          canIncrement={canIncrementAbilities}
+          onChange={setCharisma}
+        />
+      </div>
+      <div className={styles.abilitiesMetadata}>
+        Minimum: {characterRoll.min}
+        &nbsp; Maximum: {characterRoll.max}
+        &nbsp; Total: {characterRoll.total}
+        &nbsp; Remaining: {remainingAbilityPoints}
+      </div>
       <Button
-        className={styles.submit}
+        className={[styles.submit, styles.column1].join(' ')}
         text={'Create'}
         onClick={() => createCharacter({
           name: characterName,
@@ -108,13 +178,22 @@ const NewCharacter = ({ gameId, createCharacter }) => {
           race: characterRace,
           order: characterOrder,
           morality: characterMorality,
+          abilityScores: {
+            strength,
+            dexterity,
+            constitution,
+            intelligence,
+            wisdom,
+            charisma
+          },
           gameId
         })}
         disabled={!characterName ||
           !characterClass ||
           !characterRace ||
           !characterOrder ||
-          !characterMorality
+          !characterMorality ||
+          remainingAbilityPoints > 0
         }
       />
     </div>

--- a/src/components/NewCharacter/NewCharacter.module.scss
+++ b/src/components/NewCharacter/NewCharacter.module.scss
@@ -13,13 +13,13 @@
 
   .abilitiesContainer {
     grid-column: 2;
-    grid-row: 2 / span 3;
+    grid-row: 3 / span 3;
     margin-left: 50px;
   }
 
   .abilitiesMetadata {
     grid-column: 2;
-    grid-row: 5;
+    grid-row: 6;
     margin-left: 50px;
   }
 

--- a/src/components/NewCharacter/NewCharacter.module.scss
+++ b/src/components/NewCharacter/NewCharacter.module.scss
@@ -3,6 +3,25 @@
 .newCharacter {
   margin: 50px;
   position: relative;
+  display: grid;
+  grid-template-columns: auto auto;
+  grid-auto-rows: min-content;
+
+  .column1 {
+    grid-column: 1;
+  }
+
+  .abilitiesContainer {
+    grid-column: 2;
+    grid-row: 2 / span 3;
+    margin-left: 50px;
+  }
+
+  .abilitiesMetadata {
+    grid-column: 2;
+    grid-row: 5;
+    margin-left: 50px;
+  }
 
   .characterInput {
     margin: 15px auto;

--- a/src/components/common/PlusMinuser/PlusMinuser.js
+++ b/src/components/common/PlusMinuser/PlusMinuser.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import Button from '../Button/Button';
+import { string, func, number, object, bool } from 'prop-types';
+import noop from '../../../utils/noop';
+import styles from './PlusMinuser.module.scss';
+
+const PlusMinuser = ({ className, style = {}, label, initialValue, min, max, onChange, canIncrement = true }) => {
+  const [value, setValue] = useState(initialValue);
+
+  const updateValue = newValue => {
+    if (value >= min && newValue <= max) {
+      setValue(newValue);
+      onChange ? onChange(newValue) : noop();
+    }
+  };
+
+  return (
+    <div style={style} className={[styles.plusMinusHost, className].join(' ')}>
+      <div className={styles.label}>{label}</div>
+      <Button
+        className={styles.plusMinusButton}
+        text='-'
+        onClick={() => updateValue(value - 1)}
+        disabled={value <= min}
+      />
+      <Button
+        className={styles.plusMinusButton}
+        text='+'
+        onClick={() => updateValue(value + 1)}
+        disabled={!canIncrement || value >= max}
+      />
+      <div className={styles.value}>{value}</div>
+    </div>
+  );
+};
+
+PlusMinuser.propTypes = {
+  className: string,
+  style: object,
+  label: string.isRequired,
+  initialValue: number.isRequired,
+  min: number.isRequired,
+  max: number.isRequired,
+  onChange: func,
+  canIncrement: bool
+};
+
+export default PlusMinuser;

--- a/src/components/common/PlusMinuser/PlusMinuser.module.scss
+++ b/src/components/common/PlusMinuser/PlusMinuser.module.scss
@@ -1,0 +1,27 @@
+@import '../../../styles/colors.scss';
+@import '../../../styles/mixins.scss';
+
+.plusMinusHost {
+  display: flex;
+  flex-direction: row;
+  font-size: 1.5em;
+  height: 52px;
+}
+
+/* Extends the default button control class */
+.plusMinusButton {
+  width: 32px;
+  font-size: 1em;
+}
+
+.label {
+  line-height: 52px;
+  margin-right: 10px;
+  flex: 1 0;
+}
+
+.value {
+  line-height: 52px;
+  margin-left: 10px;
+  width: 30px;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5318,10 +5318,10 @@ globule@^1.0.0:
     lodash "~4.17.12"
     minimatch "~3.0.2"
 
-gm-common@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/gm-common/-/gm-common-0.1.0.tgz#aaff19c1c9d9e9abe2fdad796d126f02735a5fa2"
-  integrity sha512-pXW62C9hnSXA59Ef/cseCJGsMM7bFWNXzvwbYFvXy/G5NNXA+DWjV7lhxkue0MCtpQnTmBPstY514+xM1HJUOg==
+gm-common@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/gm-common/-/gm-common-0.1.1.tgz#3365adcfb1e2db389e78dbd1bdfa2fe5d1626886"
+  integrity sha512-CVIC+yfwu985Ttbko3SEYu7Vcgn4G+JaEAal+lUFokxdzvQkfw3W/dWbDr2IObc2SNE6Dr62B5xNEO4WoVGZaA==
 
 gonzales-pe@^4.2.4:
   version "4.2.4"


### PR DESCRIPTION
![abilities-demo](https://user-images.githubusercontent.com/8814659/78506245-507ce580-7746-11ea-985f-dfed1107f425.gif)

This adds the six ability scores to character creation, and allows them to be tweaked according to [our modification of ability allocation](https://github.com/andrew-brainerd/perkins-dungeon-master-server/wiki/Concessions-and-Modifications#rolling-for-abilities). It is dependent on an [update to `gm-common`](https://github.com/andrew-brainerd/gm-common/pull/2). It also includes creation of the `PlusMinuser` control.